### PR TITLE
Fix deploy script and hero text

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,0 +1,1 @@
+docker stack deploy -c docker-compose.yml findfruit

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { MessageCircle, Play, Star, Users } from "lucide-react";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import DemoModal from "./DemoModal";
 import PaymentModal from "./PaymentModal";
 import { sendPhotoInstruction } from "@/utils/whatsapp";
@@ -8,15 +8,6 @@ import { sendPhotoInstruction } from "@/utils/whatsapp";
 const Hero = () => {
   const [isDemoOpen, setIsDemoOpen] = useState(false);
   const [isPaymentOpen, setIsPaymentOpen] = useState(false);
-  const [currentWord, setCurrentWord] = useState("passadas");
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentWord(prev => prev === "passadas" ? "no ponto" : "passadas");
-    }, 2000);
-
-    return () => clearInterval(interval);
-  }, []);
 
   return (
     <>
@@ -37,9 +28,9 @@ const Hero = () => {
                 </div>
                 
                 <h1 className="text-4xl md:text-6xl font-bold font-poppins text-gray-900 leading-tight">
-                  {currentWord === "passadas" ? "Nunca mais compre frutas" : "Compre frutas"}{" "}
+                  Compre frutas
                   <span className="bg-gradient-to-r from-fruit-green-600 to-fruit-orange-500 bg-clip-text text-transparent transition-all duration-500">
-                    {currentWord}
+                    {" "}maduras
                   </span>
                 </h1>
                 


### PR DESCRIPTION
## Summary
- rename `deploy.taml` to `deploy.yaml` and keep deploy command
- keep hero heading text "Compre frutas maduras"

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687688850d80833380167e3c916a9027